### PR TITLE
fix: add build section in netlify toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,6 @@
 [template.environment]
-ANTHROPIC_API_KEY="Add your Anthropic API key here"
+ANTHROPIC_API_KEY = "Add your Anthropic API key here"
+
+[build]
+command = "npm run build"
+publish = "dist"


### PR DESCRIPTION
Adds `[build]` section to `netlify.toml` to fix zip based deploys
of this template.